### PR TITLE
Suggested revisions for most of the TypeScript ESLint notebook

### DIFF
--- a/TypeScript_ESLint.snb.md
+++ b/TypeScript_ESLint.snb.md
@@ -2,92 +2,176 @@
 
 ![TypeScript and ESLint logos](https://user-images.githubusercontent.com/1646931/169179393-3f1db84a-080a-4887-9f9f-78ab9dc29d4c.png)
 
-TypeScript ESLint is the de facto tool for linting in TypeScript. It's used by hundreds of thousands of projects and ensures code quality, security, and best practices across the TypeScript world. If you're deploying TypeScript into production, chances are you're using this in your toolchain.
+[TypeScript ESLint](https://typescript-eslint.io) is the de facto tool for linting in TypeScript.
+It's used by many thousands of projects and ensures code quality, security, and best practices across the TypeScript world.
+If you're deploying TypeScript into production, chances are you're using this in your toolchain.
 
-In this post, we provide a hands-on, technical introduction to how this essential static analysis tool works by tracing through its key code paths. We'll cover the following:
+In this post, we provide a hands-on, technical introduction to how this essential static analysis tool works by tracing through its key code paths.
+We'll cover the following:
 
-* How linting rules are defined
-* The use of dueling ASTs
-* A neat co-recursive switch pattern for AST traversal
+- How linting rules are defined
+- The use of dueling ASTs
+- A neat co-recursive switch pattern for AST traversal
 
 Read on!
 
 ## Overview
 
-TypeScript ESLint is implemented as a collection of packages that build on ESLint. It has a few main modules, the most important of which are:
+TypeScript ESLint is implemented as a collection of packages that build on [ESLint](https://eslint.org).
+It has a few main modules, the most important of which are:
 
-* `eslint-plugin`, which defines the ESLint plugin and the linting rules.
-* `parser` and `typescript-estree`, which are responsible for parsing TypeScript source code into an ESLint-compatible form, mapping from TypeScript ASTs to ESLint's AST representation (ESTree) and providing an API to query the AST from the rules.
+- `eslint-plugin`, which defines the ESLint plugin and the linting rules.
+- `parser` and `typescript-estree`, which are responsible for parsing TypeScript source code into an ESLint-compatible form, mapping from TypeScript ASTs to ESLint's AST representation (ESTree) and providing an API to query the AST from the rules.
 
-## How rules work
+## How Rules Work
 
-The purpose of the linter is to detect a set of patterns in source code that match common anti-patterns. These patterns are described in **rules**. The docs contain a [complete list of these rules](https://typescript-eslint.io/rules/).
+The purpose of a linter is to detect a set of patterns in source code that match common anti-patterns.
+ESLint, like many linters, defines each anti-pattern to search for in **rules**.
+ESLint's docs contain a [list of core ESLint rules](https://eslint.org/docs/rules) available for all JavaScript projects.
+TypeScript ESlint provides an additional [list of rules specific to TypeScript projects](https://typescript-eslint.io/rules).
 
-To dive into the code, let's start with the definition of a simple rule. The `no-for-in-array` rule disallows iterating over an array with a for-in loop. Here is an example of this pattern:
+For example, the `no-extra-non-null-assertion` rule catches unnecessary repeated `!`s in TypeScript code.
+Here is an example of that anti-pattern:
 
-https://sourcegraph.com/github.com/cypress-io/cypress/-/blob/packages/driver/src/cypress/proxy-logging.ts?L13
+```ts
+const scream =
+  Math.random() > 0.5 ? "What's your favorite scary movie?" : undefined;
 
-This anti-pattern is quite widespread, because it feels intuitive to use the for-in syntax to traverse an array. Doing so, however, may visit the array elements out-of-order. Instead `array.forEach` is recommended.
-
-Let's dive into the definition of this rule in source. It is short enough to include here in its entirety:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts
-
-The rule definition contains metadata at the top and the actual logic of the rule below. Let's zoom in on that logic:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L22-41
-
-There may be some unfamiliar syntax for some here. This code might look like it's defining a function called `ForInStatement` within an object declaration, but it's really just a terse variant of declaring a function value for an object key, like this:
-
-```typescript
-{
-    ForInStatement: (node): void => { ... }
-}
+// Multiple !!s are used, but only one is needed
+console.log(scream!!!.toUpperCase());
 ```
 
-This key will be used to match this rule with the name of an AST node type in the ESLint AST, so that the node argument will always have the type that the rule targets:
+Let's dig into how we can create a rule to ban those unnecessary repeated `!`s.
 
-https://sourcegraph.com/npm/typescript-eslint/types@540cca215af38ab1a49b6cde8bcb492f4b6e53c5/-/blob/dist/generated/ast-spec.d.ts?L75
+## Declaring a Rule
+
+ESLint rules are declared as objects that have two properties:
+
+- `meta`: Rule metadata such as configuration options and messages it may report
+- `create`: A function that creates the functions to be called by ESLint at runtime
+
+We're going to dive into the definition of the `no-extra-non-null-assertion` rule in source.
+It is short enough to include here in its entirety:
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
+
+Note that rules declared in the TypeScript ESLint project use a `util.createRule` helper that internally calls to an `ESLintUtils.RuleCreator`:
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/util/createRule.ts
+
+`RuleCreator` adds a documentation URL to rules under `meta.docs.url` based on their name.
+TypeScript ESLint rules are available under https://typescript-eslint.io/rules, including https://typescript-eslint.io/rules/no-extra-non-null-assertion.
+
+### Rule Metadata Properties
+
+Two particularly useful rule metadata properties are specified in many TypeScript ESLint:
+
+- `fixable`: If the rule includes an auto-fixer on any of its messages, either `"code"` or `"whitespace"`
+- `messages`: An object keying ID strings to full messages that may be reported by the rule
+
+`no-extra-non-null-assertion`'s `meta` indicates it has an auto-fixer for code issues, and that it may report _`Forbidden extra non-null assertion`_ if it detects an issue.
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L6-17
+
+### Rule Creator Functions
+
+A rule's `create` function returns an object whose keys are AST queries and whose values are functions that will be run whenever a node matching the corresponding query is found.
+The AST query keys use the [ESQuery](https://github.com/estools/esquery) library, which allows using syntax similar to CSS selectors for querying types of nodes.
+
+`no-extra-non-null-assertion` creates three node queries in its returned object:
+
+1. Any `!` non-null assertion within another `!` non-null assertion: e.g. `scream!!.length`
+2. Any `!` non-null assertion just before an `?.` optional chained property: e.g. `scream!?.length`
+3. Any `!` non-null assertion just before an `?.` optional chained call: e.g. `scream!?.()`
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L19-39
+
+Note that any AST node names prefixed with `TS`, including `TSNonNullExpression`, are TypeScript-specific nodes.
+These are available to ESLint rules when using [`@typescript-eslint/parser`](http://npmjs.com/package/@typescript-eslint/parser) instead of ESLint's built-in parser.
+The `@typescript-eslint/utils` package exports those types under the `TSESTree` namespace.
+
+⚠ TODO: link to docs page for all of them? ⚠
+
+#### Reporting on Code Issues
+
+Rule creator functions receive an ESLint "Context" object as a `context` parameter.
+That `context` object is most commonly used for its `report` method, which is what indicates a code issue has been found.
+
+`no-extra-non-null-assertion` calls `context.report` immediately for any node that matches one of its three node queries.
+It provides three properties:
+
+- `node`: The node itself, indicating the text range of the report (where to put unhappy squiggly underlines in an IDE)
+- `messageId`: Which string ID of message to report, from `meta`
+- `fix`: A function that generate instructions for how to auto-fix the code issue
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L20-30
 
 ## Type-checking
 
-One distinction between TypeScript ESLint and vanilla ESLint is that we have access to the TypeScript type checker and can therefore define rules that make use of type information.
+One powerful distinction between TypeScript ESLint and vanilla ESLint is that we have access to the TypeScript type checker.
+Rules that make use of type checking are able to make informed decisions on nodes based on their type information.
 
-The `for-in-array` rule uses the type checker to determine if we are dealing with an array type:
+TypeScript ESLint's `no-for-in-array` rule uses type information to determine if a `for-in` loop is iterating over an array rather than an object or string.
+Knowing the type of a value is only possible in JavaScript or TypeScript code if you have access to a type checker.
+Here is an example of this pattern:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L23-24
+https://sourcegraph.com/github.com/cypress-io/cypress/-/blob/packages/driver/src/cypress/proxy-logging.ts?L13
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L32-35
+This anti-pattern is quite widespread, because it feels intuitive to use the for-in syntax to traverse an array.
+Doing so, however, may visit the array elements out-of-order.
+Instead `for-of` loops or `array.forEach` are recommended.
 
-## Dual ASTs
+ESLint rules that use type information are set up similarly to other ESLint rules.
+Before we jump into how they use the type checker, the source of `no-for-in-array` is also small enough to be seen in its entirety here:
 
-In addition to invoking the type checker, the `for-in-array` rule also makes use of **two ASTs**:
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts
 
-1. the ESTree representation used by ESLint
-2. the TypeScript AST emitted by the TypeScript compiler.
+## Getting a Type Checker
 
-The `node` value passed as an argument to the rule function is from AST #1, an instance of [`TSESTree.Node`](https://sourcegraph.com/npm/typescript-eslint/types/-/blob/dist/generated/ast-spec.d.ts?L641):
+The `no-for-in-array` rule enables a `meta.docs.requiresTypeChecking` property indicating it plans on using type checking powered by a TypeScript type checker.
 
-The `originalNode` value is from AST #2, an instance of ([`TSNode`](https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/ts-estree/ts-nodes.ts?L18:13#tab=references)):
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?10
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@HEAD/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L25#tab=def
+A TypeScript type checker may be retrieved by a rule during its runtime by retrieving TypeScript ESLint's "parser services" for its `getTypeChecker()` API:
 
-Why two ASTs instead of one? Because each provides a distinct set of useful functionality.
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?23-24
 
-1. The `TSESTree` representation is used by ESLint internally and enables the plugin to reuse much of the code and linting framework provided by ESLint.
-2. The `TSNode` representation is emitted by the TypeScript compiler and contains type information.
+### Dual ASTs
 
-This rule checks if the type of the variable in the expression is an array type using the `TSNode` representation:
+One complication from using TypeScript in ESLint rules is that TypeScript type checkers don't work with the same AST format as ESLint nodes.
+TypeScript uses its own AST format.
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@HEAD/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L32-35#tab=def
+- _TSESTree_ (ESLint and TypeScript ESLint): The representation used by ESLint internally, and by TypeScript ESLint to enable the plugin to reuse much of the code and linting framework provided by ESLint
+- _TypeScript_: The representation emitted by the TypeScript compiler and what the type checker's APIs expect as inputs
 
-And then uses the `TSESTree` node to report back results to ESLint:
+TypeScript ESLint's parser services include an `esTreeNodeToTSNodeMap` mapping that allows retrieving the _TypeScript_ from the _TSESTree_ node:
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?25
+
+That original TypeScript node can then be passed to the type checker's APIs.
+Many TypeScript ESLint rules use a `getConstrainedTypeAtLocation` utility that combines of two type checking APIs to determine the type of a node:
+
+1. `getTypeAtLocation`: Given a _TypeScript_ node, its TypeScript type (`ts.Type`)
+2. `getBaseConstraintOfType`: If the TypeScript type is a generic from a type parameter, any constraint that limits what it's allowed to be (e.g. a `string[]` from `function myFunction<T extends string[]>`)
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L27:30#tab=def
+
+The rule then checks if the type is in some way an array or union of arrays:
+
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L33#tab=def
+
+If the type was an array or union of arrays, then the rule reports an issue with the original _TSESTree_ node.
 
 https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@HEAD/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L36-39
 
-In order to use both ASTs, the plugin must create both and construct a mapping between the two. The way it does so is by using a co-recursive switch pattern. Let's examine how it does this.
+### ASTs Behind The Scenes
 
-The key function is `parseAndGenerateServices`:
+In order to use both ASTs, the TypeScript ESLint plugin must create both and construct a mapping between the two.
+The way it does so is by using a "co-recursive switch" pattern: meaning it defines a recursive function containing a switch statement whose cases may each call the recursive function again.
+Let's examine how that looks.
+
+The key that starts the parsing is `parseAndGenerateServices`.
+It takes in a code string with parsing options, and returns the equivalent AST:
 
 https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3c0f2e31b9cd3824daf0909fb59754653984b813/-/blob/packages/typescript-estree/src/parser.ts?L499-502
 
@@ -111,21 +195,25 @@ https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab88902
 
 https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L105-110&subtree=true
 
-The `converter` method it invokes is co-recursive with `convertNode`, which is just a giant switch statement on the AST node type that constructs the appropriate ESLint node corresponding to the current TypeScript node. The two corresponding nodes are then added to the TypeScript-to-ESLint node mapping:
+The `converter` method it invokes is co-recursive with `convertNode`, which is just a giant switch statement on the AST node type that constructs the appropriate ESLint node corresponding to the current TypeScript node.
+The two corresponding nodes are then added to the TypeScript-to-ESLint node mapping:
 
 https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L127-132
 
 https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L770-836&subtree=true
 
-In this fashion, the TypeScript AST is converted by recursively traversing the AST and building the new ESLint one along the way. Both ASTs and the mapping between them are stored so they can be referenced by rules.
+In this fashion, the TypeScript AST is converted by recursively traversing the AST and building the new ESLint one along the way.
+Both ASTs and the mapping between them are stored so they can be referenced by rules.
 
 ## Next steps
 
-TypeScript ESLint is an amazing tool that brings the power of static analysis to multitudes of TypeScript projects. It is also an impressive case study of code reuse. Rather than build an entire linting project from scratch, it finds an elegant way to build on top of JavaScript's ESLint while integrating the TypeScript compiler to enable rules to take advantage of type information.
+TypeScript ESLint is an amazing tool that brings the power of static analysis to multitudes of TypeScript projects.
+It is also an impressive case study of code reuse.
+Rather than build an entire linting project from scratch, it finds an elegant way to build on top of JavaScript's ESLint while integrating the TypeScript compiler to enable rules to take advantage of type information.
 
 There are many ways to get involved:
 
-* [See what sorts of rules and autofixes it can apply in the playground](https://typescript-eslint.io/play/)
-* [Use it for your TypeScript codebase](https://typescript-eslint.io/docs/linting/)
-* [Contribute a new linting rule](https://typescript-eslint.io/docs/development/custom-rules)
-* [Support this open-source project financially](https://opencollective.com/typescript-eslint/contribute)
+- [See what sorts of rules and autofixes it can apply in the playground](https://typescript-eslint.io/play/)
+- [Use it for your TypeScript codebase](https://typescript-eslint.io/docs/linting/)
+- [Contribute a new linting rule](https://typescript-eslint.io/docs/development/custom-rules)
+- [Support this open-source project financially](https://opencollective.com/typescript-eslint/contribute)

--- a/TypeScript_ESLint.snb.md
+++ b/TypeScript_ESLint.snb.md
@@ -9,21 +9,26 @@ If you're deploying TypeScript into production, chances are you're using this in
 In this post, we provide a hands-on, technical introduction to how this essential static analysis tool works by tracing through its key code paths.
 We'll cover the following:
 
-- How linting rules are defined
-- The use of dueling ASTs
-- A neat co-recursive switch pattern for AST traversal
+- How ESLint rules are defined
+- How ESLint rules use ASTs to analyze code files
+- Switching between ESLint's and TypeScript's AST formats
+- Calling TypeScript's type checking APIs to analyze code
+
+> Not familiar with ASTs yet?
+> No worries!
+> Read [TypeScript ESLint's Abstract Syntax Trees (ASTs) docs page](https://typescript-eslint.io/docs/development/architecture/asts) to learn how programs represent and reason about source code.
 
 Read on!
 
 ## Overview
 
 TypeScript ESLint is implemented as a collection of packages that build on [ESLint](https://eslint.org).
-It has a few main modules, the most important of which are:
+The packages we'll be going over in this walkthrough are:
 
-- `eslint-plugin`, which defines the ESLint plugin and the linting rules.
-- `parser` and `typescript-estree`, which are responsible for parsing TypeScript source code into an ESLint-compatible form, mapping from TypeScript ASTs to ESLint's AST representation (ESTree) and providing an API to query the AST from the rules.
+- [`eslint-plugin`](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin), which defines the ESLint plugin and the linting rules.
+- [`parser`](https://www.npmjs.com/package/@typescript-eslint/parser) and [`typescript-estree`](https://www.npmjs.com/package/@typescript-eslint/typescript-estree), which are responsible for parsing TypeScript source code into an ESLint-compatible form, mapping from TypeScript ASTs to ESLint's AST representation (ESTree) and providing an API to query the AST from the rules.
 
-## How Rules Work
+### ESLint Rules
 
 The purpose of a linter is to detect a set of patterns in source code that match common anti-patterns.
 ESLint, like many linters, defines each anti-pattern to search for in **rules**.
@@ -53,25 +58,25 @@ ESLint rules are declared as objects that have two properties:
 We're going to dive into the definition of the `no-extra-non-null-assertion` rule in source.
 It is short enough to include here in its entirety:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
 
 Note that rules declared in the TypeScript ESLint project use a `util.createRule` helper that internally calls to an `ESLintUtils.RuleCreator`:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/util/createRule.ts
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/util/createRule.ts
 
 `RuleCreator` adds a documentation URL to rules under `meta.docs.url` based on their name.
-TypeScript ESLint rules are available under https://typescript-eslint.io/rules, including https://typescript-eslint.io/rules/no-extra-non-null-assertion.
+TypeScript ESLint rules are each documented on a page under https://typescript-eslint.io/rules, such as https://typescript-eslint.io/rules/no-extra-non-null-assertion.
 
 ### Rule Metadata Properties
 
-Two particularly useful rule metadata properties are specified in many TypeScript ESLint:
+Two particularly useful rule metadata properties are specified in many TypeScript ESLint rules:
 
 - `fixable`: If the rule includes an auto-fixer on any of its messages, either `"code"` or `"whitespace"`
 - `messages`: An object keying ID strings to full messages that may be reported by the rule
 
-`no-extra-non-null-assertion`'s `meta` indicates it has an auto-fixer for code issues, and that it may report _`Forbidden extra non-null assertion`_ if it detects an issue.
+`no-extra-non-null-assertion`'s `meta` indicates it has an auto-fixer for code issues and that it may report _`Forbidden extra non-null assertion`_ if it detects an issue.
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L6-17
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L6-17
 
 ### Rule Creator Functions
 
@@ -84,13 +89,16 @@ The AST query keys use the [ESQuery](https://github.com/estools/esquery) library
 2. Any `!` non-null assertion just before an `?.` optional chained property: e.g. `scream!?.length`
 3. Any `!` non-null assertion just before an `?.` optional chained call: e.g. `scream!?.()`
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L19-39
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L19-39
 
 Note that any AST node names prefixed with `TS`, including `TSNonNullExpression`, are TypeScript-specific nodes.
 These are available to ESLint rules when using [`@typescript-eslint/parser`](http://npmjs.com/package/@typescript-eslint/parser) instead of ESLint's built-in parser.
 The `@typescript-eslint/utils` package exports those types under the `TSESTree` namespace.
 
-⚠ TODO: link to docs page for all of them? ⚠
+The corresponding TypeScript types for all the possible node types are stored in a [`@typescript-eslint/types`](https://npmjs.com/package/@typescript-eslint/types) package.
+All nodes extend from a `BaseNode` interface:
+
+https://sourcegraph.com/npm/typescript-eslint/types@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/dist/generated/ast-spec.d.ts?L236-L244
 
 #### Reporting on Code Issues
 
@@ -104,18 +112,18 @@ It provides three properties:
 - `messageId`: Which string ID of message to report, from `meta`
 - `fix`: A function that generate instructions for how to auto-fix the code issue
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L20-30
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts?L20-30
 
 ## Type-checking
 
-One powerful distinction between TypeScript ESLint and vanilla ESLint is that we have access to the TypeScript type checker.
-Rules that make use of type checking are able to make informed decisions on nodes based on their type information.
+One powerful distinction between TypeScript ESLint and vanilla ESLint is that TypeScript ESLint rules have access to the TypeScript type checker.
+Rules that use type checking are able to make informed decisions on nodes based on their type information.
 
 TypeScript ESLint's `no-for-in-array` rule uses type information to determine if a `for-in` loop is iterating over an array rather than an object or string.
 Knowing the type of a value is only possible in JavaScript or TypeScript code if you have access to a type checker.
 Here is an example of this pattern:
 
-https://sourcegraph.com/github.com/cypress-io/cypress/-/blob/packages/driver/src/cypress/proxy-logging.ts?L13
+https://sourcegraph.com/github.com/cypress-io/cypress@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/driver/src/cypress/proxy-logging.ts?L13
 
 This anti-pattern is quite widespread, because it feels intuitive to use the for-in syntax to traverse an array.
 Doing so, however, may visit the array elements out-of-order.
@@ -124,17 +132,17 @@ Instead `for-of` loops or `array.forEach` are recommended.
 ESLint rules that use type information are set up similarly to other ESLint rules.
 Before we jump into how they use the type checker, the source of `no-for-in-array` is also small enough to be seen in its entirety here:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts
 
 ## Getting a Type Checker
 
 The `no-for-in-array` rule enables a `meta.docs.requiresTypeChecking` property indicating it plans on using type checking powered by a TypeScript type checker.
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?10
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L10
 
-A TypeScript type checker may be retrieved by a rule during its runtime by retrieving TypeScript ESLint's "parser services" for its `getTypeChecker()` API:
+A TypeScript type checker may be retrieved by a rule during its runtime by getting TypeScript ESLint's "parser services" for its `getTypeChecker()` API:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?23-24
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L23-24
 
 ### Dual ASTs
 
@@ -146,64 +154,26 @@ TypeScript uses its own AST format.
 
 TypeScript ESLint's parser services include an `esTreeNodeToTSNodeMap` mapping that allows retrieving the _TypeScript_ from the _TSESTree_ node:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?25
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L25
 
-That original TypeScript node can then be passed to the type checker's APIs.
+Now that the rule has obtained the _TSESTree_ node, the node can be passed to TypeScript's type checker's APIs.
+
+### Type Checking APIs
+
 Many TypeScript ESLint rules use a `getConstrainedTypeAtLocation` utility that combines of two type checking APIs to determine the type of a node:
 
 1. `getTypeAtLocation`: Given a _TypeScript_ node, its TypeScript type (`ts.Type`)
 2. `getBaseConstraintOfType`: If the TypeScript type is a generic from a type parameter, any constraint that limits what it's allowed to be (e.g. a `string[]` from `function myFunction<T extends string[]>`)
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L27:30#tab=def
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L27:30#tab=def
 
-The rule then checks if the type is in some way an array or union of arrays:
+The rule then checks if the type is in some way an array, union of arrays, or a string:
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L33#tab=def
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3cd54b7c12a07c113160ef694636721ea66b4f69@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L33-L34#tab=def
 
-If the type was an array or union of arrays, then the rule reports an issue with the original _TSESTree_ node.
+If the type was one of those disallowed types, then the rule reports an issue with the original _TSESTree_ node.
 
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@HEAD/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L36-39
-
-### ASTs Behind The Scenes
-
-In order to use both ASTs, the TypeScript ESLint plugin must create both and construct a mapping between the two.
-The way it does so is by using a "co-recursive switch" pattern: meaning it defines a recursive function containing a switch statement whose cases may each call the recursive function again.
-Let's examine how that looks.
-
-The key that starts the parsing is `parseAndGenerateServices`.
-It takes in a code string with parsing options, and returns the equivalent AST:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3c0f2e31b9cd3824daf0909fb59754653984b813/-/blob/packages/typescript-estree/src/parser.ts?L499-502
-
-This function compiles the TypeScript from source here:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/parser.ts?L595-602&subtree=true
-
-...and then converts the TypeScript AST to an ESTree-compatible one:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/parser.ts?L605-611&subtree=true
-
-The `astConverter` function makes use of the `Converter` class, which manages the state associated with the AST conversion:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/ast-converter.ts?L26-29&subtree=true
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L66-85&subtree=true#tab=def
-
-Within the `Converter` class, the `convertProgram` method kicks off the AST conversion:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L93-95&subtree=true
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L105-110&subtree=true
-
-The `converter` method it invokes is co-recursive with `convertNode`, which is just a giant switch statement on the AST node type that constructs the appropriate ESLint node corresponding to the current TypeScript node.
-The two corresponding nodes are then added to the TypeScript-to-ESLint node mapping:
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L127-132
-
-https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/typescript-estree/src/convert.ts?L770-836&subtree=true
-
-In this fashion, the TypeScript AST is converted by recursively traversing the AST and building the new ESLint one along the way.
-Both ASTs and the mapping between them are stored so they can be referenced by rules.
+https://sourcegraph.com/github.com/typescript-eslint/typescript-eslint@HEAD@3eab889022c9d1617f275017d6951f663ea57f24/-/blob/packages/eslint-plugin/src/rules/no-for-in-array.ts?L36-39
 
 ## Next steps
 
@@ -213,7 +183,7 @@ Rather than build an entire linting project from scratch, it finds an elegant wa
 
 There are many ways to get involved:
 
-- [See what sorts of rules and autofixes it can apply in the playground](https://typescript-eslint.io/play/)
-- [Use it for your TypeScript codebase](https://typescript-eslint.io/docs/linting/)
-- [Contribute a new linting rule](https://typescript-eslint.io/docs/development/custom-rules)
+- [See what sorts of rules and autofixes TypeScript ESLint can apply in the playground](https://typescript-eslint.io/play)
+- [Use TypeScript ESLint for your TypeScript codebase](https://typescript-eslint.io/docs/linting)
+- [Create a new custom linting rule](https://typescript-eslint.io/docs/development/custom-rules)
 - [Support this open-source project financially](https://opencollective.com/typescript-eslint/contribute)


### PR DESCRIPTION
This is a draft tentative rewrite of the notebook in #1. I intend it as a point of reference written from my personal narrative voice, not necessarily a direct _"use this instead"_. My guess is you'll want to pick and choose which parts of this you want to adopt in the actual pull request. Though, if you want to take the whole diff as-is and save yourself time, that works for me too! 😄 

The main changes are:

* More explanations in most of the blog post
* Introduces `no-extra-non-null-expression` as an untyped rule first, before introducing `no-for-in-array`
* As of b04fa13d: removed the `### ASTs Behind The Scenes` section

A few pedagogical strategies I tried to stick to (which were generally used in the original text too):

* Prep learners for code snippets by explaining them ahead of time
* Introduce only one topic at a time -- essentially a depth-first-search of topics 
* Explain paired concepts and object properties using different formatting, such as `*` lists or `_` italics

Note that I wrote this all in one sitting. I'll want to come back after a day or two to edit with a fresh mind.